### PR TITLE
Add GraphQL directory for fragments, queries and mutations

### DIFF
--- a/src/components/pages/WarehousePage.tsx
+++ b/src/components/pages/WarehousePage.tsx
@@ -1,28 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { DocumentNode } from "graphql/language";
-import { useQuery, gql } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 
 import ProductCard from "../custom/ProductCard";
+
+import GET_PRODUCTS from "../../graphql/queries/getProductsQuery";
 
 const WarehousePage: React.FC<PageProps> = () => {
   const [products, setProducts] = useState<Product[]>([]);
 
-  // TODO: Move GraphQL query to separate file.
-  const GET_PRODUCTS: DocumentNode = gql`
-    query {
-      getProducts {
-        id
-        name
-        supplier {
-          name
-        }
-        price
-        unit
-        photo
-        onStock
-      }
-    }
-  `;
   const { loading, error, data } = useQuery(GET_PRODUCTS);
 
   useEffect(() => {

--- a/src/graphql/queries/getProductsQuery.ts
+++ b/src/graphql/queries/getProductsQuery.ts
@@ -1,0 +1,20 @@
+import { DocumentNode } from "graphql/language";
+import { gql } from "@apollo/client";
+
+const GET_PRODUCTS: DocumentNode = gql`
+  query {
+    getProducts {
+      id
+      name
+      supplier {
+        name
+      }
+      price
+      unit
+      photo
+      onStock
+    }
+  }
+`;
+
+export default GET_PRODUCTS;


### PR DESCRIPTION
### Please verify that:

- [x] `npm run start` run

### :pencil: Description

Add separate directory for GraphQL fragments, queries and mutations. Move getProductsQuery gql query into separate file.