### PR TITLE
Rename GraphQL endpoint environment variable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ const root: ReactDOM.Root = ReactDOM.createRoot(
 );
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
-  uri: process.env.REACT_APP_ERP_API_URL,
+  uri: process.env.REACT_APP_ERP_API_GRAPHQL_ENDPOINT,
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
### Please verify that:

- [x] `npm run start` run

### :pencil: Description

Rename 'REACT_APP_ERP_API_URL' environment variable to 'REACT_APP_ERP_API_GRAPHQL_ENDPOINT'.