### PR TITLE
Set 'network-only' fetchPolicy in GraphQL querying

### DIFF
--- a/src/components/pages/WarehousePage.tsx
+++ b/src/components/pages/WarehousePage.tsx
@@ -8,7 +8,9 @@ import PRODUCTS from "../../graphql/queries/productsQuery";
 const WarehousePage: React.FC<PageProps> = () => {
   const [products, setProducts] = useState<Product[]>([]);
 
-  const { loading, error, data } = useQuery(PRODUCTS);
+  const { loading, error, data } = useQuery(PRODUCTS, {
+    fetchPolicy: "network-only",
+  });
 
   useEffect(() => {
     if (!loading && !error) {


### PR DESCRIPTION
### Please verify that:

- [x] `npm run start` run

### :pencil: Description

Use `network-only` fetch policy in GraphQL as a standard practise, to immediately refresh updated data from backend, e.g.: after photo upload when user goes to another page and goes back to WarehousePage the product photo is not visible, only after a page refresh due to GraphQL caching.