### PR TITLE
Fix toast notifications appears only once when uploading photo with wrong file extensions

### DIFF
--- a/src/components/custom/ProductCard.tsx
+++ b/src/components/custom/ProductCard.tsx
@@ -45,6 +45,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
       // @ts-ignore
     } catch (axiosError: AxiosError) {
       if (axiosError.code === NETWORK_ERROR_CODE) {
+        // TODO: In case of uploading image with unsupported file extension, toast notification appears only for the first try.
         toast.error(INTERNET_CONNECTION_ERROR_MESSAGE);
       } else {
         toast.error(axiosError.response?.data);


### PR DESCRIPTION
### Please verify that:

- [x] `npm run start` run

### :pencil: Description

Toast notifications appears only once when uploading photo with wrong file extensions just for the first try.